### PR TITLE
Conflict with doctrine/common pre-2.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
         "phpunit/phpunit": "^6.3",
         "doctrine/coding-standard": "^4.0"
     },
+    "conflict": {
+        "doctrine/common": "<2.9@dev"
+    },
     "autoload": {
         "psr-4": {
             "Doctrine\\Common\\": "lib/Doctrine/Common"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8dba4eda7c4ef3962fdf7f827a46c7fd",
+    "content-hash": "8ffec0906cedc18dba52de8cd3250b58",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
Without conflict to 2.8 and lower, there may be dragons when both are installed in parallel.
I.e. composer's optimized autoload:
```
Warning: Ambiguous class resolution, "Doctrine\Common\EventArgs" was found in both "vendor/doctrine/common/lib/Doctrine/Common/EventArgs.php" and "vendor/doctrine/event-manager/lib/Doctrine/Common/EventArgs.php", the first will be used.
Warning: Ambiguous class resolution, "Doctrine\Common\EventSubscriber" was found in both "vendor/doctrine/common/lib/Doctrine/Common/EventSubscriber.php" and "vendor/doctrine/event-manager/lib/Doctrine/Common/EventSubscriber.php", the first will be used.
Warning: Ambiguous class resolution, "Doctrine\Common\EventManager" was found in both "vendor/doctrine/common/lib/Doctrine/Common/EventManager.php" and "vendor/doctrine/event-manager/lib/Doctrine/Common/EventManager.php", the first will be used.
```

We can either ignore them (as the functionality is unaffected) or add a conflict. Conflict might make migration to standalone components a bit harder though.