### PR TITLE
Link to Slack instead of Gitter

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -10,7 +10,7 @@ Getting Help
 If this documentation is not helping to answer questions you have about the
 Doctrine DBAL, don't panic. You can get help from different sources:
 
--  Gitter chat room `#doctrine/event-manager <https://gitter.im/doctrine/event-manager>`_
+-  Slack chat room `#event-manager <https://www.doctrine-project.org/slack>`_
 -  On `Stack Overflow <http://stackoverflow.com/questions/tagged/doctrine-event-manager>`_
 -  The `Doctrine Mailing List <http://groups.google.com/group/doctrine-user>`_
 -  Report a bug on `GitHub <https://github.com/doctrine/event-manager/issues>`_.


### PR DESCRIPTION
Gitter has been deprecated in favor of Slack for all Doctrine purposes.