### PR TITLE
Split `getAllListeners()` out of `getListeners()`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,7 @@
+# Upgrade to 1.2
+
+## Deprecated calling `EventManager::getListeners()` without an event name
+
+When calling `EventManager::getListeners()` without an event name, all
+listeners were returned, keyed by event name. A new method `getAllListeners()`
+has been added to provide this functionality. It should be used instead.

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         {"name": "Marco Pivetta", "email": "ocramius@gmail.com"}
     ],
     "require": {
-        "php": "^7.1 || ^8.0"
+        "php": "^7.1 || ^8.0",
+        "doctrine/deprecations": "^0.5.3 || ^1"
     },
     "require-dev": {
         "doctrine/coding-standard": "^9 || ^10",


### PR DESCRIPTION
While #46 kind of explained the current API to static analysers, I think we should split the two ways of calling `getListeners()` into two separate methods. With this PR, I'd like to add a method `getAllListeners()` and deprecate calling `getListeners()` without an event name. This should make the API a lot cleaner in a future 2.0 release.