### PR TITLE
Bump to PHP 8.1 and add types everywhere

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,4 +13,4 @@ jobs:
     name: "PHPUnit"
     uses: "doctrine/.github/.github/workflows/continuous-integration.yml@2.1.0"
     with:
-      php-versions: '["7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]'
+      php-versions: '["8.1", "8.2"]'

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
         {"name": "Marco Pivetta", "email": "ocramius@gmail.com"}
     ],
     "require": {
-        "php": "^7.1 || ^8.0"
+        "php": "^8.1"
     },
     "require-dev": {
-        "doctrine/coding-standard": "^9 || ^10",
-        "phpstan/phpstan": "~1.4.10 || ^1.8.8",
-        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-        "vimeo/psalm": "^4.24"
+        "doctrine/coding-standard": "^10",
+        "phpstan/phpstan": "^1.8.8",
+        "phpunit/phpunit": "^9.5",
+        "vimeo/psalm": "^4.28"
     },
     "conflict": {
         "doctrine/common": "<2.9"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,26 +15,7 @@
     <file>src</file>
     <file>tests</file>
 
-    <rule ref="Doctrine">
-        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint"/>
-        <exclude name="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly.ReferencedGeneralException"/>
-
-        <!-- Adding type hints breaks backward compatibility -->
-        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/>
-
-        <!-- The null coalesce equal operator is only available in PHP 7.4+ -->
-        <exclude name="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator"/>
-    </rule>
-
-    <!-- Property type hints are only available in PHP 7.4+ -->
-    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
-        <properties>
-            <property name="enableNativeTypeHint" value="false"/>
-        </properties>
-    </rule>
+    <rule ref="Doctrine" />
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>tests/*</exclude-pattern>

--- a/src/EventArgs.php
+++ b/src/EventArgs.php
@@ -15,10 +15,8 @@ class EventArgs
 {
     /**
      * Single instance of EventArgs.
-     *
-     * @var EventArgs|null
      */
-    private static $_emptyEventArgsInstance;
+    private static EventArgs|null $emptyEventArgsInstance = null;
 
     /**
      * Gets the single, empty and immutable EventArgs instance.
@@ -31,15 +29,9 @@ class EventArgs
      *
      * @link https://msdn.microsoft.com/en-us/library/system.eventargs.aspx
      * @see EventManager::dispatchEvent
-     *
-     * @return EventArgs
      */
-    public static function getEmptyInstance()
+    public static function getEmptyInstance(): EventArgs
     {
-        if (! self::$_emptyEventArgsInstance) {
-            self::$_emptyEventArgsInstance = new EventArgs();
-        }
-
-        return self::$_emptyEventArgsInstance;
+        return self::$emptyEventArgsInstance ??= new EventArgs();
     }
 }

--- a/src/EventManager.php
+++ b/src/EventManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Common;
 
 use function spl_object_hash;
@@ -17,7 +19,7 @@ class EventManager
      *
      * @var object[][]
      */
-    private $_listeners = [];
+    private array $listeners = [];
 
     /**
      * Dispatches an event to all registered listeners.
@@ -26,18 +28,16 @@ class EventManager
      *                                  the name of the method that is invoked on listeners.
      * @param EventArgs|null $eventArgs The event arguments to pass to the event handlers/listeners.
      *                                  If not supplied, the single empty EventArgs instance is used.
-     *
-     * @return void
      */
-    public function dispatchEvent($eventName, ?EventArgs $eventArgs = null)
+    public function dispatchEvent(string $eventName, EventArgs|null $eventArgs = null): void
     {
-        if (! isset($this->_listeners[$eventName])) {
+        if (! isset($this->listeners[$eventName])) {
             return;
         }
 
-        $eventArgs = $eventArgs ?? EventArgs::getEmptyInstance();
+        $eventArgs ??= EventArgs::getEmptyInstance();
 
-        foreach ($this->_listeners[$eventName] as $listener) {
+        foreach ($this->listeners[$eventName] as $listener) {
             $listener->$eventName($eventArgs);
         }
     }
@@ -50,21 +50,17 @@ class EventManager
      * @return object[]|object[][] The event listeners for the specified event, or all event listeners.
      * @psalm-return ($event is null ? object[][] : object[])
      */
-    public function getListeners($event = null)
+    public function getListeners(string|null $event = null): array
     {
-        return $event ? $this->_listeners[$event] : $this->_listeners;
+        return $event ? $this->listeners[$event] : $this->listeners;
     }
 
     /**
      * Checks whether an event has any registered listeners.
-     *
-     * @param string $event
-     *
-     * @return bool TRUE if the specified event has any listeners, FALSE otherwise.
      */
-    public function hasListeners($event)
+    public function hasListeners(string $event): bool
     {
-        return ! empty($this->_listeners[$event]);
+        return ! empty($this->listeners[$event]);
     }
 
     /**
@@ -72,10 +68,8 @@ class EventManager
      *
      * @param string|string[] $events   The event(s) to listen on.
      * @param object          $listener The listener object.
-     *
-     * @return void
      */
-    public function addEventListener($events, $listener)
+    public function addEventListener(string|array $events, object $listener): void
     {
         // Picks the hash code related to that listener
         $hash = spl_object_hash($listener);
@@ -83,7 +77,7 @@ class EventManager
         foreach ((array) $events as $event) {
             // Overrides listener if a previous one was associated already
             // Prevents duplicate listeners on same event (same instance only)
-            $this->_listeners[$event][$hash] = $listener;
+            $this->listeners[$event][$hash] = $listener;
         }
     }
 
@@ -91,42 +85,35 @@ class EventManager
      * Removes an event listener from the specified events.
      *
      * @param string|string[] $events
-     * @param object          $listener
-     *
-     * @return void
      */
-    public function removeEventListener($events, $listener)
+    public function removeEventListener(string|array $events, object $listener): void
     {
         // Picks the hash code related to that listener
         $hash = spl_object_hash($listener);
 
         foreach ((array) $events as $event) {
-            unset($this->_listeners[$event][$hash]);
+            unset($this->listeners[$event][$hash]);
         }
     }
 
     /**
-     * Adds an EventSubscriber. The subscriber is asked for all the events it is
-     * interested in and added as a listener for these events.
+     * Adds an EventSubscriber.
      *
-     * @param EventSubscriber $subscriber The subscriber.
-     *
-     * @return void
+     * The subscriber is asked for all the events it is interested in and added
+     * as a listener for these events.
      */
-    public function addEventSubscriber(EventSubscriber $subscriber)
+    public function addEventSubscriber(EventSubscriber $subscriber): void
     {
         $this->addEventListener($subscriber->getSubscribedEvents(), $subscriber);
     }
 
     /**
-     * Removes an EventSubscriber. The subscriber is asked for all the events it is
-     * interested in and removed as a listener for these events.
+     * Removes an EventSubscriber.
      *
-     * @param EventSubscriber $subscriber The subscriber.
-     *
-     * @return void
+     * The subscriber is asked for all the events it is interested in and removed
+     * as a listener for these events.
      */
-    public function removeEventSubscriber(EventSubscriber $subscriber)
+    public function removeEventSubscriber(EventSubscriber $subscriber): void
     {
         $this->removeEventListener($subscriber->getSubscribedEvents(), $subscriber);
     }

--- a/src/EventSubscriber.php
+++ b/src/EventSubscriber.php
@@ -17,5 +17,5 @@ interface EventSubscriber
      *
      * @return string[]
      */
-    public function getSubscribedEvents();
+    public function getSubscribedEvents(): array;
 }

--- a/tests/EventManagerTest.php
+++ b/tests/EventManagerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common;
 
 use Doctrine\Common\EventArgs;
@@ -17,79 +19,73 @@ class EventManagerTest extends TestCase
     private const POST_FOO = 'postFoo';
     private const PRE_BAR  = 'preBar';
 
-    /** @var bool */
-    private $_preFooInvoked = false;
-
-    /** @var bool */
-    private $_postFooInvoked = false;
-
-    /** @var EventManager */
-    private $_eventManager;
+    private bool $preFooInvoked  = false;
+    private bool $postFooInvoked = false;
+    private EventManager $eventManager;
 
     protected function setUp(): void
     {
-        $this->_eventManager   = new EventManager();
-        $this->_preFooInvoked  = false;
-        $this->_postFooInvoked = false;
+        $this->eventManager   = new EventManager();
+        $this->preFooInvoked  = false;
+        $this->postFooInvoked = false;
     }
 
     public function testInitialState(): void
     {
-        self::assertEquals([], $this->_eventManager->getListeners());
-        self::assertFalse($this->_eventManager->hasListeners(self::PRE_FOO));
-        self::assertFalse($this->_eventManager->hasListeners(self::POST_FOO));
+        self::assertEquals([], $this->eventManager->getListeners());
+        self::assertFalse($this->eventManager->hasListeners(self::PRE_FOO));
+        self::assertFalse($this->eventManager->hasListeners(self::POST_FOO));
     }
 
     public function testAddEventListener(): void
     {
-        $this->_eventManager->addEventListener(['preFoo', 'postFoo'], $this);
-        self::assertTrue($this->_eventManager->hasListeners(self::PRE_FOO));
-        self::assertTrue($this->_eventManager->hasListeners(self::POST_FOO));
-        self::assertEquals(1, count($this->_eventManager->getListeners(self::PRE_FOO)));
-        self::assertEquals(1, count($this->_eventManager->getListeners(self::POST_FOO)));
-        self::assertEquals(2, count($this->_eventManager->getListeners()));
+        $this->eventManager->addEventListener(['preFoo', 'postFoo'], $this);
+        self::assertTrue($this->eventManager->hasListeners(self::PRE_FOO));
+        self::assertTrue($this->eventManager->hasListeners(self::POST_FOO));
+        self::assertEquals(1, count($this->eventManager->getListeners(self::PRE_FOO)));
+        self::assertEquals(1, count($this->eventManager->getListeners(self::POST_FOO)));
+        self::assertEquals(2, count($this->eventManager->getListeners()));
     }
 
     public function testDispatchEvent(): void
     {
-        $this->_eventManager->addEventListener(['preFoo', 'postFoo'], $this);
-        $this->_eventManager->dispatchEvent(self::PRE_FOO);
-        self::assertTrue($this->_preFooInvoked);
-        self::assertFalse($this->_postFooInvoked);
+        $this->eventManager->addEventListener(['preFoo', 'postFoo'], $this);
+        $this->eventManager->dispatchEvent(self::PRE_FOO);
+        self::assertTrue($this->preFooInvoked);
+        self::assertFalse($this->postFooInvoked);
     }
 
     public function testRemoveEventListener(): void
     {
-        $this->_eventManager->addEventListener(['preBar'], $this);
-        self::assertTrue($this->_eventManager->hasListeners(self::PRE_BAR));
-        $this->_eventManager->removeEventListener(['preBar'], $this);
-        self::assertFalse($this->_eventManager->hasListeners(self::PRE_BAR));
+        $this->eventManager->addEventListener(['preBar'], $this);
+        self::assertTrue($this->eventManager->hasListeners(self::PRE_BAR));
+        $this->eventManager->removeEventListener(['preBar'], $this);
+        self::assertFalse($this->eventManager->hasListeners(self::PRE_BAR));
     }
 
     public function testAddEventSubscriber(): void
     {
         $eventSubscriber = new TestEventSubscriber();
-        $this->_eventManager->addEventSubscriber($eventSubscriber);
-        self::assertTrue($this->_eventManager->hasListeners(self::PRE_FOO));
-        self::assertTrue($this->_eventManager->hasListeners(self::POST_FOO));
+        $this->eventManager->addEventSubscriber($eventSubscriber);
+        self::assertTrue($this->eventManager->hasListeners(self::PRE_FOO));
+        self::assertTrue($this->eventManager->hasListeners(self::POST_FOO));
     }
 
     public function testRemoveEventSubscriber(): void
     {
         $eventSubscriber = new TestEventSubscriber();
-        $this->_eventManager->addEventSubscriber($eventSubscriber);
-        $this->_eventManager->removeEventSubscriber($eventSubscriber);
-        self::assertFalse($this->_eventManager->hasListeners(self::PRE_FOO));
-        self::assertFalse($this->_eventManager->hasListeners(self::POST_FOO));
+        $this->eventManager->addEventSubscriber($eventSubscriber);
+        $this->eventManager->removeEventSubscriber($eventSubscriber);
+        self::assertFalse($this->eventManager->hasListeners(self::PRE_FOO));
+        self::assertFalse($this->eventManager->hasListeners(self::POST_FOO));
     }
 
     public function testNoDispatchingForUnregisteredEvent(): void
     {
-        $reflection = new ReflectionProperty(EventArgs::class, '_emptyEventArgsInstance');
-        $reflection->setAccessible(true);
+        $reflection = new ReflectionProperty(EventArgs::class, 'emptyEventArgsInstance');
         $reflection->setValue(null, null);
 
-        $this->_eventManager->dispatchEvent('unknown');
+        $this->eventManager->dispatchEvent('unknown');
 
         self::assertNull($reflection->getValue(null));
     }
@@ -98,20 +94,18 @@ class EventManagerTest extends TestCase
 
     public function preFoo(EventArgs $e): void
     {
-        $this->_preFooInvoked = true;
+        $this->preFooInvoked = true;
     }
 
     public function postFoo(EventArgs $e): void
     {
-        $this->_postFooInvoked = true;
+        $this->postFooInvoked = true;
     }
 }
 
 class TestEventSubscriber implements EventSubscriber
 {
-    /**
-     * @return string[]
-     */
+    /** @return string[] */
     public function getSubscribedEvents(): array
     {
         return ['preFoo', 'postFoo'];


### PR DESCRIPTION
Since PHP 8.1 will become the new minimum requirement for DBAL and ORM, I'd like to modernize the event manager to this language level as well.

This is a breaking change because of stricter parameter types and added native return types. If we agree to do this, I'd create a 2.0.x branch off 1.2.x and retarget this PR.