### PR TITLE
Revert return type on `EventSubscriber::getSubscribedEvents()`

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,6 +17,12 @@
 
     <rule ref="Doctrine" />
 
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint">
+        <!-- This interface is commonly implemented by userland code.
+             We omit the return type to ease the migration to 2.0 -->
+        <exclude-pattern>src/EventSubscriber.php</exclude-pattern>
+    </rule>
+
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>tests/*</exclude-pattern>
     </rule>
@@ -27,10 +33,5 @@
 
     <rule ref="Squiz.Commenting.FunctionComment.WrongStyle">
         <exclude-pattern>tests/EventManagerTest.php</exclude-pattern>
-    </rule>
-
-    <rule ref="SlevomatCodingStandard.Commenting.RequireOneLineDocComment.MultiLineDocComment">
-        <!-- Remove when dropping PHPUnit 7 -->
-        <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
 </ruleset>

--- a/src/EventSubscriber.php
+++ b/src/EventSubscriber.php
@@ -17,5 +17,5 @@ interface EventSubscriber
      *
      * @return string[]
      */
-    public function getSubscribedEvents(): array;
+    public function getSubscribedEvents();
 }


### PR DESCRIPTION
Discovered while testing DBAL 3.5 with event manager 2.0-dev. I should've known better. 😓 

Let's remove this one return type for now to ease the migration for downstream projects.