### PR TITLE
Remove doctrine/deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,8 +38,7 @@
     ],
     "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
     "require": {
-        "php": "^8.1",
-        "doctrine/deprecations": "^0.5.3 || ^1"
+        "php": "^8.1"
     },
     "require-dev": {
         "doctrine/coding-standard": "^10",


### PR DESCRIPTION
We've resolved all deprecations on the 2.0.x branch and are all set for a release. Let's remove the deprecations package because we don't need it anymore.