### PR TITLE
Add listener config to EventManager

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,7 +15,9 @@
     <file>src</file>
     <file>tests</file>
 
-    <rule ref="Doctrine" />
+    <rule ref="Doctrine">
+        <exclude name="Squiz.Commenting.FunctionComment.ExtraParamComment" />
+    </rule>
 
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint">
         <!-- This interface is commonly implemented by userland code.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,3 +3,5 @@ parameters:
   paths:
     - src/
     - tests/
+  ignoreErrors:
+    - identifier: parameter.notFound

--- a/src/EventManager.php
+++ b/src/EventManager.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Common;
 
+use function func_get_arg;
+use function func_num_args;
 use function spl_object_hash;
 
 /**
@@ -22,6 +24,14 @@ class EventManager
     private array $listeners = [];
 
     /**
+     * Map of registered listener configurations.
+     * <hash><event> => <configuration>
+     *
+     * @var array<string, array<string, array{method?: string}>>
+     */
+    private array $listenerConfigs = [];
+
+    /**
      * Dispatches an event to all registered listeners.
      *
      * @param string         $eventName The name of the event to dispatch. The name of the event is
@@ -37,8 +47,10 @@ class EventManager
 
         $eventArgs ??= EventArgs::getEmptyInstance();
 
-        foreach ($this->listeners[$eventName] as $listener) {
-            $listener->$eventName($eventArgs);
+        foreach ($this->listeners[$eventName] as $hash => $listener) {
+            $method = $this->listenerConfigs[$hash][$eventName]['method'] ?? $eventName;
+
+            $listener->$method($eventArgs);
         }
     }
 
@@ -75,18 +87,23 @@ class EventManager
     /**
      * Adds an event listener that listens on the specified events.
      *
-     * @param string|string[] $events   The event(s) to listen on.
-     * @param object          $listener The listener object.
+     * @param string|string[]                       $events         The event(s) to listen on.
+     * @param object                                $listener       The listener object.
+     * @param array<string, array{method?: string}> $listenerConfig The listener configuration, indexed by event.
      */
-    public function addEventListener(string|array $events, object $listener): void
+    public function addEventListener(string|array $events, object $listener, /* array $listenerConfig = [] */): void
     {
+        /** @var array<string, array{method?: string}> $listenerConfig */
+        $listenerConfig = 3 <= func_num_args() ? func_get_arg(2) : [];
+
         // Picks the hash code related to that listener
         $hash = spl_object_hash($listener);
 
         foreach ((array) $events as $event) {
             // Overrides listener if a previous one was associated already
             // Prevents duplicate listeners on same event (same instance only)
-            $this->listeners[$event][$hash] = $listener;
+            $this->listeners[$event][$hash]       = $listener;
+            $this->listenerConfigs[$hash][$event] = $listenerConfig[$event] ?? [];
         }
     }
 
@@ -100,6 +117,7 @@ class EventManager
         // Picks the hash code related to that listener
         $hash = spl_object_hash($listener);
 
+        unset($this->listenerConfigs[$hash]);
         foreach ((array) $events as $event) {
             unset($this->listeners[$event][$hash]);
         }

--- a/tests/EventManagerTest.php
+++ b/tests/EventManagerTest.php
@@ -19,8 +19,9 @@ class EventManagerTest extends TestCase
     private const POST_FOO = 'postFoo';
     private const PRE_BAR  = 'preBar';
 
-    private bool $preFooInvoked  = false;
-    private bool $postFooInvoked = false;
+    private bool $preFooInvoked       = false;
+    private bool $postFooInvoked      = false;
+    private bool $customMethodInvoked = false;
     private EventManager $eventManager;
 
     protected function setUp(): void
@@ -48,11 +49,31 @@ class EventManagerTest extends TestCase
         self::assertSame(['preFoo', 'postFoo'], array_keys($this->eventManager->getAllListeners()));
     }
 
+    public function testAddEventListenerWithConfig(): void
+    {
+        $this->eventManager->addEventListener(['preFoo', 'postFoo'], $this, ['preFoo' => ['method' => 'customMethod']]);
+        self::assertTrue($this->eventManager->hasListeners(self::PRE_FOO));
+        self::assertTrue($this->eventManager->hasListeners(self::POST_FOO));
+        self::assertCount(1, $this->eventManager->getListeners(self::PRE_FOO));
+        self::assertCount(1, $this->eventManager->getListeners(self::POST_FOO));
+        self::assertCount(2, $this->eventManager->getAllListeners());
+        self::assertSame(['preFoo', 'postFoo'], array_keys($this->eventManager->getAllListeners()));
+    }
+
     public function testDispatchEvent(): void
     {
         $this->eventManager->addEventListener(['preFoo', 'postFoo'], $this);
         $this->eventManager->dispatchEvent(self::PRE_FOO);
         self::assertTrue($this->preFooInvoked);
+        self::assertFalse($this->postFooInvoked);
+    }
+
+    public function testDispatchEventWithConfig(): void
+    {
+        $this->eventManager->addEventListener(['preFoo', 'postFoo'], $this, ['preFoo' => ['method' => 'customMethod']]);
+        $this->eventManager->dispatchEvent(self::PRE_FOO);
+        self::assertTrue($this->customMethodInvoked);
+        self::assertFalse($this->preFooInvoked);
         self::assertFalse($this->postFooInvoked);
     }
 
@@ -106,6 +127,11 @@ class EventManagerTest extends TestCase
     public function postFoo(EventArgs $e): void
     {
         $this->postFooInvoked = true;
+    }
+
+    public function customMethod(EventArgs $e): void
+    {
+        $this->customMethodInvoked = true;
     }
 }
 


### PR DESCRIPTION
This PR adds the possibility to have configuration when adding a listener to the event manager.

For now, it contains only a `method`: when a method is defined, it is used instead of the event name to call the listener.

It will allow to define a custom method when adding a listener for instance in Symfony:

```yaml
    App\EventListener\FooListener:
        tags:
            - { name: 'doctrine.event_listener', event: preSoftDelete, connection: custom_connection, method: onDelete }
```