### PR TITLE
Introduce EventManagerInterface

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,6 +17,10 @@
 
     <rule ref="Doctrine" />
 
+    <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix">
+        <exclude-pattern>src/EventManagerInterface.php</exclude-pattern>
+    </rule>
+
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint">
         <!-- This interface is commonly implemented by userland code.
              We omit the return type to ease the migration to 2.0 -->

--- a/src/EventManager.php
+++ b/src/EventManager.php
@@ -11,10 +11,7 @@ use function spl_object_id;
  * Listeners are registered on the manager and events are dispatched through the
  * manager.
  */
-class EventManager implements
-    EventListenerIntrospector,
-    EventListenerRegistry,
-    EventSubscriberRegistry
+class EventManager implements EventManagerInterface
 {
     /**
      * Map of registered listeners.

--- a/src/EventManagerInterface.php
+++ b/src/EventManagerInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Common;
+
+/** Provided for convenience, but consider using the individual interfaces directly. */
+interface EventManagerInterface extends
+    EventListenerIntrospector,
+    EventListenerRegistry,
+    EventSubscriberRegistry
+{
+}


### PR DESCRIPTION
In theory, having small interfaces is great, but in practice, migrating the ORM to them would involve DNF types, which are not available with PHP 8.1, for use in e.g. the constructor of EntityManager.

```diff
    public function __construct(
        private Connection $conn,
        private Configuration $config,
-       EventManager|null $eventManager = null,
+       (EventListenerIntrospector&EventListenerRegistry&EventSubscriberRegistry)|null $eventManager = null,
    ) {
```

Targeting 2.1.x since this is more fixing a design blunder than an improvement.